### PR TITLE
fix: jsonapi.Unmarshal crashes when unmarshaling an empty document

### DIFF
--- a/document_test.go
+++ b/document_test.go
@@ -379,6 +379,35 @@ func TestDocumentMarshalJSON(t *testing.T) {
 	})
 }
 
+func TestDocumentUnmarshalJSON(t *testing.T) {
+	type testcase struct {
+		name    string
+		data    string
+		want    jsonapi.Document
+		wantErr bool
+	}
+
+	for _, tc := range []testcase{
+		{
+			name:    "empty object",
+			data:    "{}",
+			want:    jsonapi.Document{},
+			wantErr: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jsonapi.Document{}
+			err := json.Unmarshal([]byte(tc.data), &got)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.EqualValues(t, tc.want, got)
+		})
+	}
+}
+
 func TestErrorNode(t *testing.T) {
 	t.Run("implements error interface", func(t *testing.T) {
 		node := jsonapi.Error{Title: "Bad Request", Detail: "bad request error"}

--- a/marshal.go
+++ b/marshal.go
@@ -211,8 +211,13 @@ func Unmarshal(doc *Document, out any) error {
 }
 
 func unmarshalOneDocument(doc *Document, out any) error {
-	item := First(doc.Data)
-	return unmarshalResource(item, reflect.ValueOf(out))
+	if doc.Data == nil {
+		return jsonapiError("unmarshal: primary data is null or missing")
+	} else if item := First(doc.Data); item == nil {
+		return jsonapiError("unmarshal: primary data is null or missing")
+	} else {
+		return unmarshalResource(item, reflect.ValueOf(out))
+	}
 }
 
 func unmarshalManyDocument(doc *Document, out any) error {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -351,6 +351,20 @@ func TestMarshalResource(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
+	t.Run("error when document primary data is null", func(t *testing.T) {
+		in := jsonapi.NewSingleDocument(nil)
+		var out SimpleItem
+		err := jsonapi.Unmarshal(in, &out)
+		assert.Error(t, err)
+	})
+
+	t.Run("error when document fields are zero value", func(t *testing.T) {
+		in := jsonapi.Document{}
+		var out SimpleItem
+		err := jsonapi.Unmarshal(&in, &out)
+		assert.Error(t, err)
+	})
+
 	t.Run("error when passing in a non-pointer", func(t *testing.T) {
 		in := jsonapi.NewSingleDocument(&jsonapi.Resource{
 			ID:         "1",


### PR DESCRIPTION
Fixes #12