### PR TITLE
perf: version bump to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 env:
-  PACKAGE_NAME: github.com/gonobo/jsonapi/v1
+  PACKAGE_NAME: github.com/gonobo/jsonapi/v2
 
 jobs:
   on-success:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # jsonapi
 
 [![Test](https://github.com/nisimpson/gibbon/actions/workflows/jsonapi-test.yml/badge.svg)](https://github.com/nisimpson/gibbon/actions/workflows/jsonapi-test.yml)
-[![GoDoc](https://godoc.org/github.com/gonobo/jsonapi/v1?status.svg)](http://godoc.org/github.com/gonobo/jsonapi/v1)
+[![GoDoc](https://godoc.org/github.com/gonobo/jsonapi/v2?status.svg)](http://godoc.org/github.com/gonobo/jsonapi/v2)
 [![Release](https://img.shields.io/github/release/gonobo/jsonapi.svg)](https://github.com/gonobo/releases)
 
 **Yet Another JSON API library for Go.**
 
-Package [`jsonapi`](http://godoc.org/github.com/gonobo/jsonapi/v1) provides structures and functions to implement [JSON API](http://jsonapi.org) compatible APIs. The library can be used with any framework and is built on top of the standard Go http library.
+Package [`jsonapi`](http://godoc.org/github.com/gonobo/jsonapi/v2) provides structures and functions to implement [JSON API](http://jsonapi.org) compatible APIs. The library can be used with any framework and is built on top of the standard Go http library.
 
 ## Installation
 
 Get the package using the go tool:
 
 ```bash
-$ go get -u github.com/gonobo/jsonapi/v1
+$ go get -u github.com/gonobo/jsonapi/v2
 ```
 
 ## Structures
@@ -138,7 +138,7 @@ to-many from being serialized.
 > unmarshal is undefined behavior.
 
 ```go
-import "github.com/gonobo/jsonapi/v1"
+import "github.com/gonobo/jsonapi/v2"
 
 func createOrder(w *http.ResponseWriter, r *http.Request) {
   in, err := jsonapi.Decode(r.Body)
@@ -159,8 +159,8 @@ JSON:API specification.
 
 ```go
 import (
-  "github.com/gonobo/jsonapi/v1"
-  "github.com/gonobo/jsonapi/v1/mux"
+  "github.com/gonobo/jsonapi/v2"
+  "github.com/gonobo/jsonapi/v2/mux"
 )
 
 func getOrder(r *http.Request) jsonapi.Response {

--- a/context.go
+++ b/context.go
@@ -3,7 +3,7 @@ package jsonapi
 import (
 	"context"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 // RequestContext contains information about the JSON:API request that defines it.

--- a/context_test.go
+++ b/context_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/document.go
+++ b/document.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gonobo/jsonapi/v1/internal/jsontest"
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/internal/jsontest"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 const LatestSupportedVersion = "1.1"

--- a/document_test.go
+++ b/document_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/extra/spec"
-	"github.com/gonobo/jsonapi/v1/jsonapitest"
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/extra/spec"
+	"github.com/gonobo/jsonapi/v2/jsonapitest"
+	"github.com/gonobo/jsonapi/v2/query"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/extra/spec/spec_test.go
+++ b/extra/spec/spec_test.go
@@ -3,8 +3,8 @@ package spec_test
 import (
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/extra/spec"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/extra/spec"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/extra/spec/validator.go
+++ b/extra/spec/validator.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 	"github.com/gonobo/validator"
 )
 

--- a/extra/visitor/visitor.go
+++ b/extra/visitor/visitor.go
@@ -3,7 +3,7 @@ package visitor
 import (
 	"errors"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 )
 
 // Visitor can traverse a JSON:API document tree. Use the subvisitors to

--- a/extra/visitor/visitor_test.go
+++ b/extra/visitor/visitor_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/extra/visitor"
-	"github.com/gonobo/jsonapi/v1/jsonapitest"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/extra/visitor"
+	"github.com/gonobo/jsonapi/v2/jsonapitest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gonobo/jsonapi/v1
+module github.com/gonobo/jsonapi/v2
 
 go 1.22.3
 

--- a/jsonapitest/jsonapitest.go
+++ b/jsonapitest/jsonapitest.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/jsonapitest"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/jsonapitest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/query/fieldset/parser.go
+++ b/query/fieldset/parser.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 var DefaultParser = Parser{}

--- a/query/filter/generator.go
+++ b/query/filter/generator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 func Generate(expr query.FilterExpression, q url.Values) error {

--- a/query/filter/parser.go
+++ b/query/filter/parser.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 	"github.com/gonobo/validator"
 )
 

--- a/query/filter/parser_test.go
+++ b/query/filter/parser_test.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1/query"
-	"github.com/gonobo/jsonapi/v1/query/filter"
+	"github.com/gonobo/jsonapi/v2/query"
+	"github.com/gonobo/jsonapi/v2/query/filter"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/query/filter/transformer.go
+++ b/query/filter/transformer.go
@@ -3,7 +3,7 @@ package filter
 import (
 	"fmt"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 // Transformer can transform [query.Filter] criteria into another [query.FilterExpression]. This is useful

--- a/query/filter_test.go
+++ b/query/filter_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/query/page/parser.go
+++ b/query/page/parser.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 var (

--- a/query/sort/parser.go
+++ b/query/sort/parser.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 var DefaultParser = RequestQueryParser{}

--- a/request_test.go
+++ b/request_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/config.go
+++ b/server/config.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 )
 
 type Config struct {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gonobo/jsonapi/v1"
+	"github.com/gonobo/jsonapi/v2"
 )
 
 var (

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/jsonapitest"
-	"github.com/gonobo/jsonapi/v1/server"
-	"github.com/gonobo/jsonapi/v1/server/middleware"
-	"github.com/gonobo/jsonapi/v1/server/servertest"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/jsonapitest"
+	"github.com/gonobo/jsonapi/v2/server"
+	"github.com/gonobo/jsonapi/v2/server/middleware"
+	"github.com/gonobo/jsonapi/v2/server/servertest"
 )
 
 type fixture struct {

--- a/server/middleware/middleware_test.go
+++ b/server/middleware/middleware_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/query"
-	"github.com/gonobo/jsonapi/v1/query/page"
-	"github.com/gonobo/jsonapi/v1/server"
-	"github.com/gonobo/jsonapi/v1/server/middleware"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/query"
+	"github.com/gonobo/jsonapi/v2/query/page"
+	"github.com/gonobo/jsonapi/v2/server"
+	"github.com/gonobo/jsonapi/v2/server/middleware"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/middleware/parsers.go
+++ b/server/middleware/parsers.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/query"
-	"github.com/gonobo/jsonapi/v1/server"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/query"
+	"github.com/gonobo/jsonapi/v2/server"
 )
 
 func UseRequestBodyParser() server.Options {

--- a/server/middleware/resolvers.go
+++ b/server/middleware/resolvers.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/server"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/server"
 )
 
 // UseRelatedResourceResolver is a middleware that handles incoming requests

--- a/server/servertest/testcase.go
+++ b/server/servertest/testcase.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1/jsonapitest"
+	"github.com/gonobo/jsonapi/v2/jsonapitest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/server/writer.go
+++ b/server/writer.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/extra/visitor"
-	"github.com/gonobo/jsonapi/v1/query"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/extra/visitor"
+	"github.com/gonobo/jsonapi/v2/query"
 )
 
 const (

--- a/server/writer_test.go
+++ b/server/writer_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gonobo/jsonapi/v1"
-	"github.com/gonobo/jsonapi/v1/query"
-	"github.com/gonobo/jsonapi/v1/server"
+	"github.com/gonobo/jsonapi/v2"
+	"github.com/gonobo/jsonapi/v2/query"
+	"github.com/gonobo/jsonapi/v2/server"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Go version sematics allow attaching `v_` syntax starting at version 2.